### PR TITLE
Remove "purchase labels" action when there are no carrier accounts

### DIFF
--- a/packages/app/src/hooks/useShipmentDetails.tsx
+++ b/packages/app/src/hooks/useShipmentDetails.tsx
@@ -15,7 +15,9 @@ export const shipmentIncludeAttribute = [
 
   'parcels',
   'parcels.package',
-  'parcels.parcel_line_items'
+  'parcels.parcel_line_items',
+
+  'carrier_accounts'
 ]
 
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type

--- a/packages/app/src/hooks/useViewStatus.tsx
+++ b/packages/app/src/hooks/useViewStatus.tsx
@@ -24,6 +24,8 @@ export function useViewStatus(shipment: Shipment): ViewStatus {
   const pickingList = usePickingList(shipment)
   const hasPickingItems = pickingList.length > 0
   const hasParcels = shipment.parcels != null && shipment.parcels.length > 0
+  const hasCarrierAccounts =
+    shipment.carrier_accounts != null && shipment.carrier_accounts.length > 0
 
   return useMemo(() => {
     const purchased = hasBeenPurchased(shipment)
@@ -59,15 +61,24 @@ export function useViewStatus(shipment: Shipment): ViewStatus {
           ]
         } else {
           if (!purchased) {
-            result.contextActions = [
-              { label: 'Mark as ready', triggerAttribute: '_ready_to_ship' }
-            ]
-            result.footerActions = [
-              {
-                label: 'Purchase labels',
-                triggerAttribute: '_get_rates'
-              }
-            ]
+            if (hasCarrierAccounts) {
+              result.contextActions = [
+                { label: 'Mark as ready', triggerAttribute: '_ready_to_ship' }
+              ]
+              result.footerActions = [
+                {
+                  label: 'Purchase labels',
+                  triggerAttribute: '_get_rates'
+                }
+              ]
+            } else {
+              result.footerActions = [
+                {
+                  label: 'Mark as ready',
+                  triggerAttribute: '_ready_to_ship'
+                }
+              ]
+            }
           }
         }
         break


### PR DESCRIPTION
## What I did

When there are no carrier accounts the purchase labels action is not available.
