### PR TITLE
Prefill total package weight if all items have it

### DIFF
--- a/packages/app/src/pages/Packing.tsx
+++ b/packages/app/src/pages/Packing.tsx
@@ -30,6 +30,24 @@ export function Packing(): JSX.Element {
   const { createParcelError, createParcelWithItems, isCreatingParcel } =
     useCreateParcel(shipmentId)
 
+  const defaultWeight = useMemo<string>(() => {
+    let totalWeight = 0
+
+    for (const item of shipment.stock_line_items ?? []) {
+      if (
+        item.stock_item?.sku?.weight == null ||
+        item.stock_item?.sku?.weight <= 0
+      ) {
+        totalWeight = 0
+        break
+      }
+
+      totalWeight += item.stock_item.sku.weight * item.quantity
+    }
+
+    return totalWeight > 0 ? totalWeight.toString() : ''
+  }, [shipment])
+
   const defaultUnitOfWeight = useMemo(
     () =>
       uniq(
@@ -108,7 +126,7 @@ export function Packing(): JSX.Element {
               value: item.id
             })),
             packageId: '',
-            weight: '',
+            weight: defaultWeight,
             unitOfWeight: defaultUnitOfWeight
           }}
           stockLineItems={pickingList}


### PR DESCRIPTION
## What I did

If all `skus` found in `stock_line_items` have a weight set, we prefill the package weight input.
For the current UX iteration we decided to do not update/sync the input once the user has interacted with checkboxes, also there is no correlation with unit of weights and we don't force unit any conversion.

This is intended to be an optimistic default input value, valid only as initial state

<img width="571" alt="image" src="https://github.com/commercelayer/app-shipments/assets/30926550/c8e70615-c88b-4a9d-9d5d-acad8f79300c">


## How to test

<!-- Please include the steps to test your changes here -->

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [x] Make sure to add/update documentation regarding your changes.
- [x] You are **NOT** deprecating/removing a feature.
