### PR TITLE
Add counters in Home page

### DIFF
--- a/packages/app/src/data/lists.ts
+++ b/packages/app/src/data/lists.ts
@@ -1,0 +1,35 @@
+import type { FormFullValues } from '@commercelayer/app-elements/dist/ui/resources/useResourceFilters/types'
+
+export type ListType =
+  | 'picking'
+  | 'packing'
+  | 'readyToShip'
+  | 'onHold'
+  | 'history'
+
+export const presets: Record<ListType, FormFullValues> = {
+  picking: {
+    status_eq: 'picking',
+    archived_at_null: 'show',
+    viewTitle: 'Picking'
+  },
+  packing: {
+    status_eq: 'packing',
+    archived_at_null: 'show',
+    viewTitle: 'Packing'
+  },
+  readyToShip: {
+    status_eq: 'ready_to_ship',
+    archived_at_null: 'show',
+    viewTitle: 'Ready to ship'
+  },
+  onHold: {
+    status_eq: 'on_hold',
+    archived_at_null: 'show',
+    viewTitle: 'On hold'
+  },
+  history: {
+    archived_at_null: 'hide',
+    viewTitle: 'All shipments'
+  }
+}

--- a/packages/app/src/metricsApi/fetcher.ts
+++ b/packages/app/src/metricsApi/fetcher.ts
@@ -1,0 +1,25 @@
+interface MetricsApiFetcherParams {
+  endpoint: string
+  slug: string
+  accessToken: string
+  body: Record<string, any>
+}
+
+export const metricsApiFetcher = async <Data>({
+  endpoint,
+  slug,
+  accessToken,
+  body
+}: MetricsApiFetcherParams): Promise<VndApiResponse<Data>> => {
+  const url = `https://${slug}.${window.clAppConfig.domain}/metrics${endpoint}`
+  const response = await fetch(url, {
+    method: 'POST',
+    headers: {
+      accept: 'application/vnd.api.v1+json',
+      'content-type': 'application/vnd.api+json',
+      authorization: `Bearer ${accessToken}`
+    },
+    body: JSON.stringify(body)
+  })
+  return await response.json()
+}

--- a/packages/app/src/metricsApi/types.d.ts
+++ b/packages/app/src/metricsApi/types.d.ts
@@ -1,0 +1,18 @@
+interface MetricsApiShipmentsBreakdownItem {
+  label: string
+  value: number
+}
+
+interface MetricsApiShipmentsBreakdownData {
+  'shipments.status': MetricsApiShipmentsBreakdownItem[]
+}
+
+interface VndApiResponse<Data> {
+  data: Data
+  meta: {
+    pagination: {
+      record_count: number
+      cursor: string | null
+    }
+  }
+}

--- a/packages/app/src/metricsApi/useListCounters.ts
+++ b/packages/app/src/metricsApi/useListCounters.ts
@@ -1,0 +1,103 @@
+import { presets, type ListType } from '#data/lists'
+import { useTokenProvider } from '@commercelayer/app-elements'
+import useSWR, { type SWRResponse } from 'swr'
+import { metricsApiFetcher } from './fetcher'
+import { getLastYearIsoRange } from './utils'
+
+const fetchShipmentStats = async ({
+  slug,
+  accessToken,
+  filters
+}: {
+  slug: string
+  accessToken: string
+  filters: object
+}): Promise<VndApiResponse<MetricsApiShipmentsBreakdownData>> =>
+  await metricsApiFetcher<MetricsApiShipmentsBreakdownData>({
+    endpoint: '/orders/breakdown',
+    slug,
+    accessToken,
+    body: {
+      breakdown: {
+        by: 'shipments.status',
+        field: 'shipments.id',
+        operator: 'value_count'
+      },
+      filter: {
+        order: {
+          ...getLastYearIsoRange(new Date()),
+          date_field: 'updated_at'
+        },
+        ...filters
+      }
+    }
+  })
+
+const fetchAllCounters = async ({
+  slug,
+  accessToken
+}: {
+  slug: string
+  accessToken: string
+}): Promise<{
+  picking: number
+  packing: number
+  readyToShip: number
+  onHold: number
+}> => {
+  const lists: ListType[] = ['picking', 'packing', 'readyToShip', 'onHold']
+  const listsStatuses = lists.map((listType) => presets[listType].status_eq)
+
+  const allStats = await fetchShipmentStats({
+    slug,
+    accessToken,
+    filters: {
+      shipments: {
+        statuses: {
+          in: listsStatuses
+        }
+      }
+    }
+  })
+
+  const stats = allStats.data
+
+  return {
+    picking: getShipmentsBreakdownCounterByStatus(stats, 'picking'),
+    packing: getShipmentsBreakdownCounterByStatus(stats, 'packing'),
+    readyToShip: getShipmentsBreakdownCounterByStatus(stats, 'ready_to_ship'),
+    onHold: getShipmentsBreakdownCounterByStatus(stats, 'on_hold')
+  }
+}
+
+export function useListCounters(): SWRResponse<{
+  picking: number
+  packing: number
+  readyToShip: number
+  onHold: number
+}> {
+  const {
+    settings: { accessToken, organizationSlug }
+  } = useTokenProvider()
+
+  const swrResponse = useSWR(
+    {
+      slug: organizationSlug,
+      accessToken
+    },
+    fetchAllCounters,
+    {
+      revalidateOnFocus: false
+    }
+  )
+
+  return swrResponse
+}
+
+function getShipmentsBreakdownCounterByStatus(
+  allStats: MetricsApiShipmentsBreakdownData,
+  status: 'picking' | 'packing' | 'on_hold' | 'ready_to_ship'
+): number {
+  const stats = allStats['shipments.status']
+  return stats?.filter((stat) => stat.label === status)[0]?.value ?? 0
+}

--- a/packages/app/src/metricsApi/utils.test.ts
+++ b/packages/app/src/metricsApi/utils.test.ts
@@ -1,0 +1,11 @@
+import { getLastYearIsoRange } from './utils'
+describe('getLastYearIsoRange', () => {
+  test('should return last year range', () => {
+    const now = new Date('2023-04-24T13:45:00.000Z')
+    const result = getLastYearIsoRange(now)
+    expect(result).toEqual({
+      date_from: '2022-04-24T13:45:00Z',
+      date_to: '2023-04-24T13:45:00Z'
+    })
+  })
+})

--- a/packages/app/src/metricsApi/utils.ts
+++ b/packages/app/src/metricsApi/utils.ts
@@ -1,0 +1,24 @@
+function removeMilliseconds(isoDate: string): string {
+  return (isoDate.split('.')[0] ?? '') + 'Z'
+}
+
+/**
+ * Returns one year date range ready to be used in  Metrics APIs request body.
+ * It will remove milliseconds from the Date ISO strings.
+ * Example:
+ * ```
+ * { date_from: '2022-04-24T13:45:00Z', date_to: '2023-04-24T13:45:00Z' }
+ * ```
+ */
+export function getLastYearIsoRange(now: Date): {
+  date_from: string
+  date_to: string
+} {
+  const to = removeMilliseconds(now.toISOString())
+  const nowYear = now.getFullYear()
+  const from = to.replace(`${nowYear}`, (nowYear - 1).toString())
+  return {
+    date_from: from,
+    date_to: to
+  }
+}

--- a/packages/app/src/pages/Home.tsx
+++ b/packages/app/src/pages/Home.tsx
@@ -6,6 +6,7 @@ import {
   List,
   ListItem,
   PageLayout,
+  SkeletonTemplate,
   Spacer,
   Text,
   useResourceFilters,
@@ -15,6 +16,7 @@ import type { Shipment } from '@commercelayer/sdk'
 import { useCallback } from 'react'
 import { Link, useLocation } from 'wouter'
 import { useSearch } from 'wouter/use-location'
+import { useListCounters } from '../metricsApi/useListCounters'
 
 export function Home(): JSX.Element {
   const {
@@ -24,6 +26,8 @@ export function Home(): JSX.Element {
 
   const search = useSearch()
   const [, setLocation] = useLocation()
+
+  const { data: counters, isLoading: isLoadingCounters } = useListCounters()
 
   const { SearchWithNav, adapters } = useResourceFilters({
     instructions: filtersInstructions
@@ -62,51 +66,61 @@ export function Home(): JSX.Element {
         queryString={search}
       />
 
-      <Spacer bottom='14'>
-        <List title='Pending'>
-          <Link href={getPresetUrlByStatus('picking')}>
-            <ListItem
-              tag='a'
-              icon={<Icon name='arrowDown' background='orange' gap='small' />}
-            >
-              <Text weight='semibold'>Picking</Text>
-              <Icon name='caretRight' />
-            </ListItem>
-          </Link>
+      <SkeletonTemplate isLoading={isLoadingCounters}>
+        <Spacer bottom='14'>
+          <List title='Pending'>
+            <Link href={getPresetUrlByStatus('picking')}>
+              <ListItem
+                tag='a'
+                icon={<Icon name='arrowDown' background='orange' gap='small' />}
+              >
+                <Text weight='semibold'>
+                  Picking {formatCounter(counters?.picking)}
+                </Text>
+                <Icon name='caretRight' />
+              </ListItem>
+            </Link>
 
-          <Link href={getPresetUrlByStatus('packing')}>
-            <ListItem
-              tag='a'
-              icon={<Icon name='package' background='orange' gap='small' />}
-            >
-              <Text weight='semibold'>Packing</Text>
-              <Icon name='caretRight' />
-            </ListItem>
-          </Link>
+            <Link href={getPresetUrlByStatus('packing')}>
+              <ListItem
+                tag='a'
+                icon={<Icon name='package' background='orange' gap='small' />}
+              >
+                <Text weight='semibold'>
+                  Packing {formatCounter(counters?.packing)}
+                </Text>
+                <Icon name='caretRight' />
+              </ListItem>
+            </Link>
 
-          <Link href={getPresetUrlByStatus('ready_to_ship')}>
-            <ListItem
-              tag='a'
-              icon={
-                <Icon name='arrowUpRight' background='orange' gap='small' />
-              }
-            >
-              <Text weight='semibold'>Ready to ship</Text>
-              <Icon name='caretRight' />
-            </ListItem>
-          </Link>
+            <Link href={getPresetUrlByStatus('ready_to_ship')}>
+              <ListItem
+                tag='a'
+                icon={
+                  <Icon name='arrowUpRight' background='orange' gap='small' />
+                }
+              >
+                <Text weight='semibold'>
+                  Ready to ship {formatCounter(counters?.readyToShip)}
+                </Text>
+                <Icon name='caretRight' />
+              </ListItem>
+            </Link>
 
-          <Link href={getPresetUrlByStatus('on_hold')}>
-            <ListItem
-              tag='a'
-              icon={<Icon name='hourglass' background='orange' gap='small' />}
-            >
-              <Text weight='semibold'>On hold</Text>
-              <Icon name='caretRight' />
-            </ListItem>
-          </Link>
-        </List>
-      </Spacer>
+            <Link href={getPresetUrlByStatus('on_hold')}>
+              <ListItem
+                tag='a'
+                icon={<Icon name='hourglass' background='orange' gap='small' />}
+              >
+                <Text weight='semibold'>
+                  On hold {formatCounter(counters?.onHold)}
+                </Text>
+                <Icon name='caretRight' />
+              </ListItem>
+            </Link>
+          </List>
+        </Spacer>
+      </SkeletonTemplate>
 
       <Spacer bottom='14'>
         <List title='Browse'>
@@ -123,4 +137,8 @@ export function Home(): JSX.Element {
       </Spacer>
     </PageLayout>
   )
+}
+
+function formatCounter(counter = 0): string {
+  return `(${Intl.NumberFormat().format(counter)})`
 }


### PR DESCRIPTION
<!-- Thank you for contributing to Commerce Layer! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

Added Home page counters based on breakdown queries of `metrics API`.
This app is the first one to implement breakdown queries of the metrics api to gather in a single request the whole set of counters.

<img width="500" alt="Screenshot 2023-12-14 alle 17 38 12" src="https://github.com/commercelayer/app-shipments/assets/105653649/9606a658-0868-4847-b77a-f5ee7e4e1383">

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [ ] Make sure to add/update documentation regarding your changes.
- [x] You are **NOT** deprecating/removing a feature.
