### PR TITLE
Fix Shipment detail back behavior

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -11,7 +11,7 @@
   // format on save
   // "editor.formatOnSave": true,
   "editor.codeActionsOnSave": {
-    "source.fixAll": true,
-    "source.organizeImports": true
+    "source.fixAll": "explicit",
+    "source.organizeImports": "explicit"
   }
 }

--- a/packages/app/src/pages/ShipmentDetails.tsx
+++ b/packages/app/src/pages/ShipmentDetails.tsx
@@ -21,7 +21,7 @@ import {
   useTokenProvider
 } from '@commercelayer/app-elements'
 import isEmpty from 'lodash/isEmpty'
-import { Link, useLocation, useRoute } from 'wouter'
+import { useLocation, useRoute } from 'wouter'
 
 export function ShipmentDetails(): JSX.Element {
   const {
@@ -43,9 +43,12 @@ export function ShipmentDetails(): JSX.Element {
         title='Orders'
         navigationButton={{
           onClick: () => {
-            setLocation(appRoutes.home.makePath())
+            goBack({
+              setLocation,
+              defaultRelativePath: appRoutes.home.makePath()
+            })
           },
-          label: 'Shipments',
+          label: 'Back',
           icon: 'arrowLeft'
         }}
         mode={mode}
@@ -53,9 +56,17 @@ export function ShipmentDetails(): JSX.Element {
         <EmptyState
           title='Not authorized'
           action={
-            <Link href={appRoutes.home.makePath()}>
-              <Button variant='primary'>Go back</Button>
-            </Link>
+            <Button
+              variant='primary'
+              onClick={() => {
+                goBack({
+                  setLocation,
+                  defaultRelativePath: appRoutes.home.makePath()
+                })
+              }}
+            >
+              Go back
+            </Button>
           }
         />
       </PageLayout>
@@ -101,7 +112,7 @@ export function ShipmentDetails(): JSX.Element {
             defaultRelativePath: appRoutes.home.makePath()
           })
         },
-        label: 'Shipments',
+        label: 'Back',
         icon: 'arrowLeft'
       }}
       gap='only-top'


### PR DESCRIPTION
<!-- Thank you for contributing to Commerce Layer! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

Fixed `shipment detail page` back button behavior by restoring the `goBack` helper

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [ ] Make sure to add/update documentation regarding your changes.
- [x] You are **NOT** deprecating/removing a feature.
