### PR TITLE
Allow to mark a shipment as delivered and to filters by delivered status

### DIFF
--- a/packages/app/src/data/filters.ts
+++ b/packages/app/src/data/filters.ts
@@ -7,6 +7,8 @@ const allowedStatuses: Array<Shipment['status']> = [
   'packing',
   'ready_to_ship',
   'shipped',
+  // @ts-expect-error waiting for new types from SDK
+  'delivered',
   'on_hold'
 ]
 

--- a/packages/app/src/hooks/useViewStatus.tsx
+++ b/packages/app/src/hooks/useViewStatus.tsx
@@ -111,6 +111,17 @@ export function useViewStatus(shipment: Shipment): ViewStatus {
             ]
         break
 
+      case 'shipped':
+        result.contextActions = []
+        result.footerActions = [
+          {
+            label: 'Mark as delivered',
+            // @ts-expect-error waiting for SDK types to be updated
+            triggerAttribute: '_deliver'
+          }
+        ]
+        break
+
       case 'on_hold':
         result.footerActions =
           activeStockTransfers.length === 0


### PR DESCRIPTION
## What I did

I've added the `delivered` status to the filter options and add the button to mark a shipment as delivered (only if status is `shipped`)

## How to test

<!-- Please include the steps to test your changes here -->

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [ ] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [ ] Make sure to add/update documentation regarding your changes.
- [ ] You are **NOT** deprecating/removing a feature.
